### PR TITLE
docs: add API key limit env vars to ENV.md

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -109,6 +109,15 @@ docker-compose up -d
 
 ---
 
+## API Key Limits (Optional)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_KEY_MAX_PER_USER` | `10` | Maximum number of personal API keys per user |
+| `API_KEY_MAX_SERVICE_PER_ORG` | `100` | Maximum number of service API keys per organization |
+
+---
+
 ## Enterprise / Licensing (Optional)
 
 | Variable | Default | Description |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documented optional env vars to configure API key limits in `ENV.md`. Adds `API_KEY_MAX_PER_USER` (default 10) and `API_KEY_MAX_SERVICE_PER_ORG` (default 100) to set per-user and per-organization limits.

<sup>Written for commit 129639cfc575992d0d75e47a7f1d2ba542fc1f2d. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium/pull/120">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

