### PR TITLE
feat: add release workflow automation

### DIFF
--- a/.github/scripts/apply-version-metadata.mjs
+++ b/.github/scripts/apply-version-metadata.mjs
@@ -1,0 +1,41 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function versionFiles() {
+  return (process.env.VERSION_FILES || '')
+    .split(/\r?\n/)
+    .map((file) => file.trim())
+    .filter(Boolean);
+}
+
+function updateJsonVersion(path, version) {
+  const doc = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+  if (doc.info && typeof doc.info === 'object' && 'version' in doc.info) {
+    doc.info.version = version;
+  } else if ('version' in doc) {
+    doc.version = version;
+  } else {
+    throw new Error(`${path} does not contain info.version or version`);
+  }
+
+  fs.writeFileSync(path, `${JSON.stringify(doc, null, 2)}\n`);
+}
+
+const version = requiredEnv('TARGET_VERSION');
+
+execFileSync('npm', ['version', version, '--no-git-tag-version', '--allow-same-version'], {
+  stdio: 'inherit',
+});
+
+for (const file of versionFiles()) {
+  updateJsonVersion(file, version);
+}

--- a/.github/scripts/check-prerelease-deps.mjs
+++ b/.github/scripts/check-prerelease-deps.mjs
@@ -1,0 +1,24 @@
+import fs from 'node:fs/promises';
+
+const pkg = JSON.parse(await fs.readFile('package.json', 'utf8'));
+const sections = ['dependencies', 'peerDependencies', 'optionalDependencies'];
+const prereleaseVersionPattern = /(?:^|[^\w.-])v?\d+\.\d+\.\d+-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*/;
+const violations = [];
+
+for (const section of sections) {
+  const deps = pkg[section];
+  if (!deps) continue;
+
+  for (const [name, version] of Object.entries(deps)) {
+    if (prereleaseVersionPattern.test(String(version))) {
+      violations.push(`${section}: ${name}@${version}`);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('Stable releases cannot depend on prerelease runtime dependencies:');
+  for (const violation of violations) console.error(`- ${violation}`);
+  console.error('Release stable dependency versions first, or publish this package as a prerelease.');
+  process.exit(1);
+}

--- a/.github/scripts/create-github-app-commit.mjs
+++ b/.github/scripts/create-github-app-commit.mjs
@@ -1,0 +1,171 @@
+import fs from 'node:fs';
+
+const apiVersion = '2022-11-28';
+
+class GitHubError extends Error {
+  constructor(message, status, responseBody) {
+    super(message);
+    this.name = 'GitHubError';
+    this.status = status;
+    this.responseBody = responseBody;
+  }
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function optionalEnv(name, fallback = '') {
+  return process.env[name] || fallback;
+}
+
+function positiveIntegerEnv(name, fallback) {
+  const raw = optionalEnv(name, fallback);
+  if (!/^[1-9][0-9]*$/.test(raw)) {
+    throw new Error(`${name} must be a positive integer, got "${raw}"`);
+  }
+  return Number.parseInt(raw, 10);
+}
+
+function appendOutput(name, value) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
+async function github(method, path, body) {
+  const repo = requiredEnv('GITHUB_REPOSITORY');
+  const token = requiredEnv('GH_TOKEN');
+  const response = await fetch(`https://api.github.com/repos/${repo}${path}`, {
+    method,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      'x-github-api-version': apiVersion,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new GitHubError(`${method} ${path} failed with ${response.status}: ${text}`, response.status, text);
+  }
+
+  return text ? JSON.parse(text) : null;
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function retryDelayMs(attempt) {
+  const baseDelay = Math.min(15_000, 2 ** (attempt - 1) * 1000);
+  return baseDelay + Math.floor(Math.random() * 250);
+}
+
+async function commitFiles() {
+  const files = requiredEnv('COMMIT_FILES')
+    .split(/\r?\n/)
+    .map((file) => file.trim())
+    .filter(Boolean);
+
+  if (files.length === 0) {
+    throw new Error('COMMIT_FILES must contain at least one path');
+  }
+
+  const entries = [];
+  for (const path of files) {
+    const blob = await github('POST', '/git/blobs', {
+      content: fs.readFileSync(path, 'utf8'),
+      encoding: 'utf-8',
+    });
+
+    entries.push({
+      path,
+      mode: '100644',
+      type: 'blob',
+      sha: blob.sha,
+    });
+  }
+
+  return entries;
+}
+
+async function updateRef(refMode, targetBranch, commitSha) {
+  const ref = `refs/heads/${targetBranch}`;
+
+  if (refMode === 'create') {
+    await github('POST', '/git/refs', {
+      ref,
+      sha: commitSha,
+    });
+    return ref;
+  }
+
+  const maxAttempts = positiveIntegerEnv('REF_UPDATE_ATTEMPTS', '3');
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await github('PATCH', `/git/refs/heads/${targetBranch}`, {
+        sha: commitSha,
+        force: false,
+      });
+      return ref;
+    } catch (error) {
+      const retryable = error instanceof GitHubError && error.status >= 500 && error.status < 600;
+      if (!retryable || attempt === maxAttempts) {
+        throw error;
+      }
+
+      const delay = retryDelayMs(attempt);
+      console.warn(
+        `Ref update failed with ${error.status}: ${error.responseBody}; retrying in ${delay}ms (${attempt}/${maxAttempts})`,
+      );
+      await sleep(delay);
+    }
+  }
+
+  throw new Error(`Failed to update ${ref}`);
+}
+
+const baseSha = requiredEnv('BASE_SHA');
+const targetBranch = requiredEnv('TARGET_BRANCH');
+const refMode = requiredEnv('REF_MODE');
+const message = requiredEnv('COMMIT_MESSAGE');
+
+if (!['create', 'update'].includes(refMode)) {
+  throw new Error(`REF_MODE must be create or update, got ${refMode}`);
+}
+
+const baseCommit = await github('GET', `/git/commits/${baseSha}`);
+const tree = await github('POST', '/git/trees', {
+  base_tree: baseCommit.tree.sha,
+  tree: await commitFiles(),
+});
+
+const commit = await github('POST', '/git/commits', {
+  message,
+  tree: tree.sha,
+  parents: [baseSha],
+});
+
+if (!commit.verification?.verified) {
+  const reason = commit.verification?.reason || 'unknown';
+  throw new Error(`GitHub did not verify the release bot commit (${reason})`);
+}
+
+const ref = await updateRef(refMode, targetBranch, commit.sha);
+
+appendOutput('commit_sha', commit.sha);
+appendOutput('verification_reason', commit.verification.reason || '');
+appendOutput('branch_ref', ref);
+
+console.log(`Created verified GitHub App commit ${commit.sha} on ${ref}`);
+console.log(`Verification reason: ${commit.verification.reason || 'unknown'}`);
+const summary = optionalEnv('COMMIT_SUMMARY');
+if (summary) {
+  console.log(summary);
+}

--- a/.github/scripts/validate-version-metadata.mjs
+++ b/.github/scripts/validate-version-metadata.mjs
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function versionFiles() {
+  return (process.env.VERSION_FILES || '')
+    .split(/\r?\n/)
+    .map((file) => file.trim())
+    .filter(Boolean);
+}
+
+function readJson(path) {
+  return JSON.parse(fs.readFileSync(path, 'utf8'));
+}
+
+function assertEqual(label, actual, expected) {
+  console.log(`${label}: ${actual}`);
+  if (actual !== expected) {
+    throw new Error(`${label} mismatch: ${actual} != ${expected}`);
+  }
+}
+
+function versionFromJson(path) {
+  const doc = readJson(path);
+  if (doc.info && typeof doc.info === 'object' && 'version' in doc.info) {
+    return doc.info.version;
+  }
+  return doc.version;
+}
+
+const version = requiredEnv('TARGET_VERSION');
+const pkg = readJson('package.json');
+const lock = readJson('package-lock.json');
+
+assertEqual('package.json version', pkg.version, version);
+assertEqual('package-lock.json version', lock.version, version);
+assertEqual('package-lock root version', lock.packages?.['']?.version, version);
+
+for (const file of versionFiles()) {
+  assertEqual(`${file} version`, versionFromJson(file), version);
+}
+
+console.log(`tag version: ${version}`);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
   workflow_call:
     secrets:
       DOCKERHUB_USERNAME:
@@ -21,22 +24,47 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Determine latest stable Docker tag eligibility
+        id: stable-tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          IS_LATEST_STABLE=false
+          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            LATEST_STABLE_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+            if [[ "$GITHUB_REF_NAME" == "$LATEST_STABLE_TAG" ]]; then
+              IS_LATEST_STABLE=true
+            fi
+          fi
+
+          echo "is_latest_stable=$IS_LATEST_STABLE" >> "$GITHUB_OUTPUT"
 
       - name: Log in to the Container registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f #docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ steps.stable-tag.outputs.is_latest_stable == 'true' }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 #docker/build-push-action@v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,121 @@
+name: Publish Standalone Package to npmjs
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.11.1
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Validate tag format
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "Publishing standalone package for tag: $TAG"
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|rc)\.[0-9]+)?$ ]]; then
+            echo "Invalid tag format: $TAG (expected vX.Y.Z, vX.Y.Z-alpha.N, or vX.Y.Z-rc.N)"
+            exit 1
+          fi
+
+          VERSION=${TAG#v}
+          echo "TARGET_VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate root package and lockfile versions
+        run: node .github/scripts/validate-version-metadata.mjs
+
+      - name: Ensure stable releases do not depend on prereleases
+        run: |
+          if [[ "$TARGET_VERSION" == *-* ]]; then
+            echo "Skipping stable dependency guard for prerelease $TARGET_VERSION"
+            exit 0
+          fi
+          node .github/scripts/check-prerelease-deps.mjs
+
+      - name: Build standalone package
+        run: npm run standalone:build
+
+      - name: Validate standalone package version
+        run: |
+          set -euo pipefail
+          PACKAGE_NAME=$(node -p "require('./standalone/package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./standalone/package.json').version")
+
+          echo "standalone package: $PACKAGE_NAME"
+          echo "standalone version: $PACKAGE_VERSION"
+          echo "tag version: $TARGET_VERSION"
+
+          if [[ "$PACKAGE_NAME" != "@revisium/standalone" ]]; then
+            echo "Unexpected standalone package name: $PACKAGE_NAME"
+            exit 1
+          fi
+
+          if [[ "$PACKAGE_VERSION" != "$TARGET_VERSION" ]]; then
+            echo "Standalone version mismatch: $PACKAGE_VERSION != $TARGET_VERSION"
+            exit 1
+          fi
+
+      - name: Smoke test standalone package
+        run: bash scripts/standalone-smoke-test.sh
+
+      - name: Ensure npm version does not already exist
+        run: |
+          PACKAGE_NAME=$(node -p "require('./standalone/package.json').name")
+          LOOKUP_ERR=$(mktemp)
+          PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME@$TARGET_VERSION" version 2>"$LOOKUP_ERR" || true)
+
+          if [[ -s "$LOOKUP_ERR" ]]; then
+            echo "Warning: npm registry lookup produced stderr:"
+            cat "$LOOKUP_ERR"
+          fi
+          rm -f "$LOOKUP_ERR"
+
+          if [[ -n "$PUBLISHED_VERSION" ]]; then
+            echo "$PACKAGE_NAME@$TARGET_VERSION is already published"
+            exit 1
+          fi
+
+      - name: Determine npm tag
+        id: npm-tag
+        run: |
+          set -euo pipefail
+
+          VERSION="$TARGET_VERSION"
+          if [[ "$VERSION" =~ -alpha ]]; then
+            echo "tag=alpha" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" =~ -rc ]]; then
+            echo "tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            LATEST_STABLE_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+            if [[ "v$VERSION" == "$LATEST_STABLE_TAG" ]]; then
+              echo "tag=latest" >> "$GITHUB_OUTPUT"
+            else
+              IFS=. read -r MAJOR MINOR PATCH <<< "$VERSION"
+              echo "tag=release-$MAJOR-$MINOR" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Publish standalone to npm
+        run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}
+        working-directory: standalone
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,19 +2,13 @@ name: Pipeline
 
 on:
   push:
-    branches: [master]
+    branches: [master, 'release/**']
   pull_request:
-    branches: [master]
-  release:
-    types: [published]
+    branches: [master, 'release/**']
   workflow_dispatch:
     inputs:
       docker:
         description: 'Build and push Docker image'
-        type: boolean
-        default: false
-      npm-publish:
-        description: 'Publish to npm'
         type: boolean
         default: false
       deploy:
@@ -88,8 +82,7 @@ jobs:
   docker:
     needs: smoke-test
     if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'release' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
       (github.event_name == 'workflow_dispatch' && inputs.docker)
     permissions:
       contents: read
@@ -98,47 +91,10 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  npm-publish:
-    needs: smoke-test
-    if: >-
-      github.event_name == 'release' ||
-      (github.event_name == 'workflow_dispatch' && inputs.npm-publish)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: standalone-package
-          path: standalone/
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24.11.1
-          registry-url: 'https://registry.npmjs.org'
-      - name: Determine npm tag
-        id: npm-tag
-        working-directory: standalone
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" =~ -alpha ]]; then
-            echo "tag=alpha" >> $GITHUB_OUTPUT
-          elif [[ "$VERSION" =~ -beta ]]; then
-            echo "tag=beta" >> $GITHUB_OUTPUT
-          elif [[ "$VERSION" =~ -rc ]]; then
-            echo "tag=rc" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-      - run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}
-        working-directory: standalone
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   deploy:
     needs: docker
     if: >-
-      github.event_name == 'push' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
       (github.event_name == 'workflow_dispatch' && inputs.deploy)
     permissions:
       contents: read

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,0 +1,369 @@
+name: Release Train
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Release train transition
+        required: true
+        type: choice
+        options:
+          - start-minor-alpha
+          - start-major-alpha
+          - start-minor-rc
+          - start-major-rc
+          - start-minor-stable
+          - start-major-stable
+          - alpha-bump
+          - promote-rc
+          - rc-bump
+          - stable
+          - patch
+          - patch-alpha-start
+          - patch-rc-start
+      dry_run:
+        description: Validate and show the computed release without pushing.
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.repository }}-release-train
+  cancel-in-progress: false
+
+# Keep GITHUB_TOKEN read-only. Release commits and branch refs are created with
+# the release GitHub App so the version commit receives GitHub's Verified badge.
+# The tag is pushed with the same App token so downstream tag workflows run.
+permissions:
+  contents: read
+
+jobs:
+  release-train:
+    runs-on: ubuntu-latest
+    env:
+      ACTION: ${{ inputs.action }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      VERSION_FILES: ''
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.11.1
+          cache: 'npm'
+
+      - name: Create release app token
+        id: app-token
+        if: ${{ inputs.dry_run == false }}
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Compute release transition
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+
+          CURRENT_BRANCH=${GITHUB_REF_NAME}
+          ACTION="$ACTION"
+
+          if [[ "$ACTION" == start-* ]]; then
+            if [[ "$CURRENT_BRANCH" != "master" ]]; then
+              echo "start-* actions must run from master. Current branch: $CURRENT_BRANCH"
+              exit 1
+            fi
+
+            ACTIVE_TRAINS=()
+            while IFS= read -r BRANCH; do
+              [[ -z "$BRANCH" ]] && continue
+              VERSION=$(git show "$BRANCH:package.json" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+              if [[ "$VERSION" =~ -(alpha|rc)\.[0-9]+$ ]]; then
+                ACTIVE_TRAINS+=("$BRANCH ($VERSION)")
+              fi
+            done < <(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/release/*')
+
+            if (( ${#ACTIVE_TRAINS[@]} > 0 )); then
+              echo "Cannot start a new release train while a prerelease train is active:"
+              printf -- '- %s\n' "${ACTIVE_TRAINS[@]}"
+              exit 1
+            fi
+
+            LATEST_STABLE_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+            if [[ -z "$LATEST_STABLE_TAG" ]]; then
+              echo "No stable tag found. Create an initial stable tag before using release trains."
+              exit 1
+            fi
+
+            BASE_VERSION=${LATEST_STABLE_TAG#v}
+            IFS=. read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+
+            case "$ACTION" in
+              start-minor-*)
+                TARGET_MAJOR="$MAJOR"
+                TARGET_MINOR=$((MINOR + 1))
+                ;;
+              start-major-*)
+                TARGET_MAJOR=$((MAJOR + 1))
+                TARGET_MINOR=0
+                ;;
+              *)
+                echo "Unsupported start action: $ACTION"
+                exit 1
+                ;;
+            esac
+
+            TARGET_BASE="$TARGET_MAJOR.$TARGET_MINOR.0"
+            case "$ACTION" in
+              *-alpha) TARGET_VERSION="$TARGET_BASE-alpha.0" ;;
+              *-rc) TARGET_VERSION="$TARGET_BASE-rc.0" ;;
+              *-stable) TARGET_VERSION="$TARGET_BASE" ;;
+              *)
+                echo "Unsupported start action: $ACTION"
+                exit 1
+                ;;
+            esac
+
+            TARGET_BRANCH="release/$TARGET_MAJOR.$TARGET_MINOR.x"
+            if git ls-remote --exit-code --heads origin "$TARGET_BRANCH" >/dev/null 2>&1; then
+              echo "Target branch already exists: $TARGET_BRANCH"
+              exit 1
+            fi
+
+            SOURCE_SHA=$(git rev-parse origin/master^{commit})
+            git switch -c "$TARGET_BRANCH" "$SOURCE_SHA"
+          else
+            if [[ ! "$CURRENT_BRANCH" =~ ^release/[0-9]+\.[0-9]+\.x$ ]]; then
+              echo "$ACTION must run from release/X.Y.x. Current branch: $CURRENT_BRANCH"
+              exit 1
+            fi
+
+            TARGET_BRANCH="$CURRENT_BRANCH"
+            BRANCH_LINE=${CURRENT_BRANCH#release/}
+            BRANCH_LINE=${BRANCH_LINE%.x}
+            IFS=. read -r TARGET_MAJOR TARGET_MINOR <<< "$BRANCH_LINE"
+            CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+            if [[ ! "$CURRENT_VERSION" =~ ^$TARGET_MAJOR\.$TARGET_MINOR\. ]]; then
+              echo "package.json version $CURRENT_VERSION does not match branch $CURRENT_BRANCH"
+              exit 1
+            fi
+
+            case "$ACTION" in
+              alpha-bump)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
+                  echo "alpha-bump requires current version X.Y.Z-alpha.N"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const v='$CURRENT_VERSION'; const m=v.match(/^(.+-alpha\.)([0-9]+)$/); console.log(m[1] + (Number(m[2]) + 1));")
+                ;;
+              promote-rc)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
+                  echo "promote-rc requires current version X.Y.Z-alpha.N"
+                  exit 1
+                fi
+                TARGET_VERSION=${CURRENT_VERSION%%-alpha.*}-rc.0
+                ;;
+              rc-bump)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+                  echo "rc-bump requires current version X.Y.Z-rc.N"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const v='$CURRENT_VERSION'; const m=v.match(/^(.+-rc\.)([0-9]+)$/); console.log(m[1] + (Number(m[2]) + 1));")
+                ;;
+              stable)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|rc)\.[0-9]+$ ]]; then
+                  echo "stable requires current version X.Y.Z-alpha.N or X.Y.Z-rc.N"
+                  exit 1
+                fi
+                TARGET_VERSION=${CURRENT_VERSION%%-*}
+                ;;
+              patch)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "patch requires stable current version X.Y.Z"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const [a,b,c]='$CURRENT_VERSION'.split('.').map(Number); console.log([a,b,c+1].join('.'));")
+                ;;
+              patch-alpha-start)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "patch-alpha-start requires stable current version X.Y.Z"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const [a,b,c]='$CURRENT_VERSION'.split('.').map(Number); console.log([a,b,c+1].join('.') + '-alpha.0');")
+                ;;
+              patch-rc-start)
+                if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "patch-rc-start requires stable current version X.Y.Z"
+                  exit 1
+                fi
+                TARGET_VERSION=$(node -e "const [a,b,c]='$CURRENT_VERSION'.split('.').map(Number); console.log([a,b,c+1].join('.') + '-rc.0');")
+                ;;
+              *)
+                echo "Unsupported action on release branch: $ACTION"
+                exit 1
+                ;;
+            esac
+          fi
+
+          if [[ ! "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|rc)\.[0-9]+)?$ ]]; then
+            echo "Computed invalid target version: $TARGET_VERSION"
+            exit 1
+          fi
+
+          IFS=. read -r VERSION_MAJOR VERSION_MINOR _ <<< "${TARGET_VERSION%%-*}"
+          if [[ "$VERSION_MAJOR" != "$TARGET_MAJOR" || "$VERSION_MINOR" != "$TARGET_MINOR" ]]; then
+            echo "Target version $TARGET_VERSION does not match target branch $TARGET_BRANCH"
+            exit 1
+          fi
+
+          TAG="v$TARGET_VERSION"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag already exists locally: $TAG"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag already exists on origin: $TAG"
+            exit 1
+          fi
+
+          echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "target_version=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if [[ "$ACTION" == start-* ]]; then
+            echo "ref_mode=create" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref_mode=update" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply version metadata
+        env:
+          TARGET_VERSION: ${{ steps.release.outputs.target_version }}
+        run: node .github/scripts/apply-version-metadata.mjs
+
+      - name: Validate stable runtime dependencies
+        if: ${{ !contains(steps.release.outputs.target_version, '-') }}
+        run: node .github/scripts/check-prerelease-deps.mjs
+
+      - name: Validate release metadata
+        id: metadata
+        env:
+          TARGET_VERSION: ${{ steps.release.outputs.target_version }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/validate-version-metadata.mjs
+
+          ALLOWED_FILES=("package.json" "package-lock.json")
+          while IFS= read -r FILE; do
+            [[ -z "$FILE" ]] && continue
+            ALLOWED_FILES+=("$FILE")
+          done <<< "${VERSION_FILES:-}"
+
+          while IFS= read -r FILE; do
+            [[ -z "$FILE" ]] && continue
+            ALLOWED=false
+            for ALLOWED_FILE in "${ALLOWED_FILES[@]}"; do
+              if [[ "$FILE" == "$ALLOWED_FILE" ]]; then
+                ALLOWED=true
+                break
+              fi
+            done
+            if [[ "$ALLOWED" != "true" ]]; then
+              echo "Release commit may not change $FILE"
+              exit 1
+            fi
+          done <<< "$(git diff --name-only)"
+
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create test .env
+        run: cp .env.example .env
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:ci
+
+      - name: Type check
+        run: npm run tsc
+
+      - name: Build standalone package
+        run: npm run standalone:build
+
+      - name: Smoke test standalone package
+        run: bash scripts/standalone-smoke-test.sh
+
+      - name: Create verified release commit
+        id: release-commit
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_BRANCH: ${{ steps.release.outputs.target_branch }}
+          TARGET_VERSION: ${{ steps.release.outputs.target_version }}
+          METADATA_CHANGED: ${{ steps.metadata.outputs.changed }}
+          REF_MODE: ${{ steps.release.outputs.ref_mode }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "RELEASE_BOT_CLIENT_ID and RELEASE_BOT_PRIVATE_KEY are required to create verified release commits"
+            exit 1
+          fi
+
+          BASE_SHA=$(git rev-parse HEAD)
+          export BASE_SHA
+          export COMMIT_MESSAGE="chore(release): $TARGET_VERSION"
+          COMMIT_FILES=$'package.json\npackage-lock.json'
+          while IFS= read -r FILE; do
+            [[ -z "$FILE" ]] && continue
+            COMMIT_FILES="$COMMIT_FILES"$'\n'"$FILE"
+          done <<< "${VERSION_FILES:-}"
+          export COMMIT_FILES
+          export COMMIT_SUMMARY="Metadata changed: $METADATA_CHANGED"
+
+          node .github/scripts/create-github-app-commit.mjs
+
+      - name: Push release tag
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_BRANCH: ${{ steps.release.outputs.target_branch }}
+          TAG: ${{ steps.release.outputs.tag }}
+          COMMIT_SHA: ${{ steps.release-commit.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" || -z "${COMMIT_SHA:-}" ]]; then
+            echo "Release App token and verified commit SHA are required before pushing the tag"
+            exit 1
+          fi
+
+          git fetch origin "refs/heads/$TARGET_BRANCH:refs/remotes/origin/$TARGET_BRANCH"
+          FETCHED_SHA=$(git rev-parse "refs/remotes/origin/$TARGET_BRANCH")
+          if [[ "$FETCHED_SHA" != "$COMMIT_SHA" ]]; then
+            echo "Release branch $TARGET_BRANCH points at $FETCHED_SHA, expected $COMMIT_SHA"
+            exit 1
+          fi
+
+          git tag "$TAG" "$COMMIT_SHA"
+          git push "https://x-access-token:$GH_TOKEN@github.com/${{ github.repository }}" "$TAG"
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run only. No commit, branch, or tag was pushed."
+          echo "Target branch: ${{ steps.release.outputs.target_branch }}"
+          echo "Target version: ${{ steps.release.outputs.target_version }}"
+          echo "Tag: ${{ steps.release.outputs.tag }}"

--- a/.github/workflows/stable-version-sync.yml
+++ b/.github/workflows/stable-version-sync.yml
@@ -1,0 +1,144 @@
+name: Stable Version Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable version to mirror on master, without leading v.
+        required: true
+      dry_run:
+        description: Validate and show changes without opening a PR.
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.repository }}-stable-version-sync
+  cancel-in-progress: false
+
+# Keep GITHUB_TOKEN read-only. Sync branches and PRs use the release GitHub App.
+permissions:
+  contents: read
+
+jobs:
+  stable-version-sync:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      VERSION_FILES: ''
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.11.1
+          cache: 'npm'
+
+      - name: Validate target version
+        run: |
+          set -euo pipefail
+          git fetch origin '+refs/tags/*:refs/tags/*'
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Stable version sync requires X.Y.Z without prerelease suffix"
+            exit 1
+          fi
+
+          if ! git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "Stable tag does not exist: v$VERSION"
+            exit 1
+          fi
+
+          LATEST_STABLE_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+          if [[ "$LATEST_STABLE_TAG" != "v$VERSION" ]]; then
+            echo "Requested version v$VERSION is not the latest stable tag ($LATEST_STABLE_TAG)"
+            exit 1
+          fi
+
+      - name: Apply stable version metadata
+        env:
+          TARGET_VERSION: ${{ inputs.version }}
+        run: node .github/scripts/apply-version-metadata.mjs
+
+      - name: Validate changed files
+        id: metadata
+        run: |
+          set -euo pipefail
+          CHANGED_FILES=$(git diff --name-only)
+
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "Master already mirrors v$VERSION"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          while IFS= read -r FILE; do
+            case "$FILE" in
+              package.json|package-lock.json) ;;
+              *)
+                echo "Stable version sync may not change $FILE"
+                exit 1
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create release app token
+        id: app-token
+        if: ${{ inputs.dry_run == false && steps.metadata.outputs.changed == 'true' }}
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Create pull request
+        if: ${{ inputs.dry_run == false && steps.metadata.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "RELEASE_BOT_CLIENT_ID and RELEASE_BOT_PRIVATE_KEY are required to create the sync branch and open a PR"
+            exit 1
+          fi
+
+          BRANCH="chore/sync-stable-v$VERSION"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Sync branch already exists: $BRANCH"
+            exit 1
+          fi
+
+          BASE_SHA=$(git rev-parse HEAD)
+          export BASE_SHA
+          export TARGET_BRANCH="$BRANCH"
+          export REF_MODE="create"
+          export COMMIT_MESSAGE="chore: sync stable version $VERSION"
+          export COMMIT_FILES=$'package.json\npackage-lock.json'
+
+          node .github/scripts/create-github-app-commit.mjs
+
+          if ! gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "chore: sync stable version $VERSION" \
+            --body "Mirrors the already-published stable tag v$VERSION on master. This PR updates version metadata only."; then
+            echo "PR creation failed; deleting orphan branch $BRANCH"
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$BRANCH" || true
+            exit 1
+          fi
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run only. No branch or PR was created."
+          git diff --stat

--- a/standalone/DEVELOPMENT.md
+++ b/standalone/DEVELOPMENT.md
@@ -69,10 +69,15 @@ These env vars have no effect on Docker builds — the code falls back to `__dir
 
 ## Publish
 
-```bash
-cd standalone
-npm publish --access public --tag alpha
-```
+The `@revisium/standalone` package is published by the `Publish Standalone Package to npmjs`
+workflow when a release tag is pushed:
+
+- `vX.Y.Z-alpha.N` publishes with npm tag `alpha`
+- `vX.Y.Z-rc.N` publishes with npm tag `rc`
+- `vX.Y.Z` publishes with npm tag `latest` only when it is the highest stable tag
+- older stable maintenance releases publish with npm tag `release-X-Y`
+
+Build locally with `npm run standalone:build` and inspect with `cd standalone && npm pack`.
 
 ## Testing Locally
 

--- a/standalone/build.sh
+++ b/standalone/build.sh
@@ -102,5 +102,5 @@ console.log('  admin (bundled): ' + template.revisiumAdmin);
 echo ""
 echo "Standalone package ready at $SCRIPT_DIR"
 echo ""
-echo "To publish:  cd standalone && npm publish --access public --tag alpha"
+echo "Publishing is handled by the v* tag workflow."
 echo "To inspect:  cd standalone && npm pack"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automates releases end-to-end with a verified GitHub App: release trains, tag-driven Docker images, and npm publishing for `@revisium/standalone`. Enforces strict version checks and blocks prerelease runtime deps in stable builds.

- **New Features**
  - Release Train workflow: start minor/major (alpha/rc/stable), bump/promote (alpha→rc, rc bump, stable), patch flows; includes dry-run.
  - Verified release commits and tags via GitHub App; commits may change only version files, with extra JSON allowed via `VERSION_FILES`.
  - Docker: tag-triggered builds on `v*`; publishes `X.Y.Z`, `X.Y`, and `latest` for the newest stable.
  - npm: tag-triggered publish for `@revisium/standalone` with `alpha`/`rc`/`latest` dist-tags, `release-X-Y` for older stable lines, version validation, and smoke tests.
  - Stable Version Sync: mirrors the latest stable tag’s version metadata onto `master` via an automated PR.
  - Utility scripts: apply/validate version metadata, prerelease dependency guard, and GitHub App verified commit creation.

- **Refactors**
  - Pipeline restricts Docker/deploy to `master` pushes or manual runs; supports `release/**`; removes in-pipeline npm publish.
  - Updated standalone docs and build script to reference tag-based publishing.

<sup>Written for commit 422bec31596b064961b8baef7f1488a42aad34e7. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium/pull/121">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

