### PR TITLE
chore: connect core next alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@nestjs/platform-express": "^11.1.11",
         "@nestjs/swagger": "^11.2.4",
         "@revisium/admin": "^2.6.0-alpha.0",
-        "@revisium/core": "^2.10.0-alpha.0",
+        "@revisium/core": "^2.10.0-alpha.1",
         "@revisium/endpoint": "^2.6.0-alpha.0",
         "graphql": "^16.12.0"
       },
@@ -6101,9 +6101,9 @@
       }
     },
     "node_modules/@revisium/core": {
-      "version": "2.10.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@revisium/core/-/core-2.10.0-alpha.0.tgz",
-      "integrity": "sha512-jjzk2XcWRpdEToMdRiPt3vEoOpyqcMVurGz53BybPk9KMUXmxb5/YguBUbR3KoPB/SEK9tBBCbsw5cXXCvDIZQ==",
+      "version": "2.10.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@revisium/core/-/core-2.10.0-alpha.1.tgz",
+      "integrity": "sha512-gvnE3Nc4E5n+QtvAMzDYUYlsannYYl6hv+mISXxxSlz/hQ/CFXtmgI2vZThEWvdsLw40zITgOVs54cQj5l+fUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.816.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nestjs/platform-express": "^11.1.11",
     "@nestjs/swagger": "^11.2.4",
     "@revisium/admin": "^2.6.0-alpha.0",
-    "@revisium/core": "^2.10.0-alpha.0",
+    "@revisium/core": "^2.10.0-alpha.1",
     "@revisium/endpoint": "^2.6.0-alpha.0",
     "graphql": "^16.12.0"
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `@revisium/core` to ^2.10.0-alpha.1 to align with the next alpha release and pick up recent fixes. Only dependency and lockfile updates; no app code changes.

<sup>Written for commit de5600d9b0ade39d3ae594970a509af1430216fa. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium/pull/124">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

