### PR TITLE
fix: align docker builder with runtime base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.11.1 AS builder
+FROM node:24.11.1-bullseye AS builder
 
 ENV NODE_ENV=development
 

--- a/ENV.md
+++ b/ENV.md
@@ -150,8 +150,8 @@ Standalone CLI options:
 | `CORE_API_URL`               | `http://0.0.0.0:{PORT}`                                      | Core API base URL used by endpoint.                          |
 | `CORE_API_URL_USERNAME`      | -                                                            | Deprecated endpoint-to-core password auth username.          |
 | `CORE_API_URL_PASSWORD`      | -                                                            | Deprecated endpoint-to-core password auth password.          |
-| `INTERNAL_API_KEY_ENDPOINT`  | derived in monolith; required/preferred in microservice mode | Internal API key for endpoint-to-core auth.                  |
-| `INTERNAL_API_KEY_{SERVICE}` | -                                                            | Internal API key for an additional service.                  |
+| `INTERNAL_API_KEY_ENDPOINT`  | derived in monolith; required/preferred in microservice mode | Internal API key for endpoint-to-core auth. In microservice mode, must match the core value and `/^rev_[A-Za-z0-9_-]{22}$/`. |
+| `INTERNAL_API_KEY_{SERVICE}` | -                                                            | Internal API key for an additional service. Values must match `/^rev_[A-Za-z0-9_-]{22}$/`. |
 | `INTERNAL_MONOLITH_SERVICES` | `endpoint`                                                   | Comma-separated services for derived monolith internal keys. |
 
 ## Admin Runtime


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced microservice mode configuration documentation by clarifying the required format specifications and constraints for internal API key endpoints and service-specific authentication keys in microservice deployments.

* **Chores**
  * Updated Docker build infrastructure with a specific Node.js base image version for improved consistency and enhanced compatibility across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->