### PR TITLE
fix: robots txt control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ PORT=8080
 #TRUST_PROXY=
 #CORS_ORIGIN=
 #REVISIUM_STANDALONE=1
+#REVISIUM_ROBOTS_TXT=
 
 # Database (required outside @revisium/standalone)
 DATABASE_URL=

--- a/ENV.md
+++ b/ENV.md
@@ -18,6 +18,7 @@ This document lists the environment variables consumed by the Revisium self-host
 | `STORAGE_LOCAL_PATH`          | `<data>/uploads` unless set          | Local file uploads directory.                                          |
 | `PUBLIC_URL`                  | `http://localhost:{PORT}`            | Public base URL for OAuth, MCP, and local file URLs.                   |
 | `FILE_PLUGIN_PUBLIC_ENDPOINT` | `PUBLIC_URL/files` for local storage | Public file URL prefix for local storage.                              |
+| `REVISIUM_ROBOTS_TXT`          | `User-agent: *` + `Disallow: /` | Full `/robots.txt` content. Use `\n` for line breaks in env values. When unset/empty, standalone also sends `X-Robots-Tag: noindex, nofollow, noarchive`. |
 | `REVISIUM_CLIENT_DIR`         | package `client/`                    | Admin UI assets.                                                       |
 | `REVISIUM_TEMPLATES_DIR`      | package `templates/`                 | Email templates.                                                       |
 
@@ -47,6 +48,7 @@ Standalone CLI options:
 | `NODE_ENV`    | -                                                                           | Used for production-sensitive defaults such as cookies and CORS.                  |
 | `TRUST_PROXY` | unset                                                                       | Express `trust proxy` value: `true`, `false`, integer hop count, or IP/CIDR list. |
 | `CORS_ORIGIN` | dev: reflect request origin; production: same-origin only                   | Comma-separated credentialed CORS allowlist.                                      |
+| `REVISIUM_ROBOTS_TXT` | `User-agent: *` + `Disallow: /`                                                  | Full `/robots.txt` content. Use `\n` for line breaks in env values. When unset/empty, responses include `X-Robots-Tag: noindex, nofollow, noarchive`. Set this value to take full control of crawler rules. |
 
 ## Authentication
 

--- a/src/configure-http-app.ts
+++ b/src/configure-http-app.ts
@@ -2,6 +2,7 @@ import { Logger, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import * as cookieParser from 'cookie-parser';
+import { configureRobotsIndexing } from './robots-indexing';
 
 const DEFAULT_BODY_LIMIT = '10mb';
 
@@ -60,6 +61,7 @@ export function configureHttpApp(app: NestExpressApplication): ConfigService {
   const bodyLimit = config.get<string>('BODY_LIMIT') ?? DEFAULT_BODY_LIMIT;
 
   configureTrustProxy(app, config);
+  configureRobotsIndexing(app, config);
 
   app.useBodyParser('json', { limit: bodyLimit });
   app.use(cookieParser());

--- a/src/robots-indexing.spec.ts
+++ b/src/robots-indexing.spec.ts
@@ -1,0 +1,28 @@
+import { getRobotsTxt } from './robots-indexing';
+
+describe('robots-indexing', () => {
+  it.each([[undefined], [null], ['']])(
+    'uses a private-by-default robots.txt when env is %s',
+    (value) => {
+      expect(getRobotsTxt(value)).toBe('User-agent: *\nDisallow: /\n');
+    },
+  );
+
+  it('uses the custom robots.txt value', () => {
+    expect(getRobotsTxt('User-agent: *\nAllow: /')).toBe(
+      'User-agent: *\nAllow: /\n',
+    );
+  });
+
+  it('supports escaped newlines in the custom robots.txt value', () => {
+    expect(getRobotsTxt('User-agent: *\\nAllow: /')).toBe(
+      'User-agent: *\nAllow: /\n',
+    );
+  });
+
+  it('preserves the custom robots.txt trailing newline', () => {
+    expect(getRobotsTxt('User-agent: *\nAllow: /\n')).toBe(
+      'User-agent: *\nAllow: /\n',
+    );
+  });
+});

--- a/src/robots-indexing.spec.ts
+++ b/src/robots-indexing.spec.ts
@@ -15,7 +15,7 @@ describe('robots-indexing', () => {
   });
 
   it('supports escaped newlines in the custom robots.txt value', () => {
-    expect(getRobotsTxt('User-agent: *\\nAllow: /')).toBe(
+    expect(getRobotsTxt(String.raw`User-agent: *\nAllow: /`)).toBe(
       'User-agent: *\nAllow: /\n',
     );
   });

--- a/src/robots-indexing.ts
+++ b/src/robots-indexing.ts
@@ -1,0 +1,39 @@
+import type { ConfigService } from '@nestjs/config';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import type { NextFunction, Request, Response } from 'express';
+
+export const ROBOTS_TXT_ENV = 'REVISIUM_ROBOTS_TXT';
+export const ROBOTS_NOINDEX_HEADER_VALUE = 'noindex, nofollow, noarchive';
+
+const DEFAULT_ROBOTS_TXT = 'User-agent: *\nDisallow: /\n';
+
+export function getRobotsTxt(value: string | null | undefined): string {
+  if (value === undefined || value === null || value === '') {
+    return DEFAULT_ROBOTS_TXT;
+  }
+
+  const robotsTxt = value.replace(/\\n/g, '\n');
+  return robotsTxt.endsWith('\n') ? robotsTxt : `${robotsTxt}\n`;
+}
+
+export function configureRobotsIndexing(
+  app: NestExpressApplication,
+  config: ConfigService,
+): void {
+  const robotsTxt = config.get<string>(ROBOTS_TXT_ENV);
+  const hasCustomRobotsTxt = robotsTxt !== undefined && robotsTxt !== '';
+
+  if (!hasCustomRobotsTxt) {
+    app.use((_req: Request, res: Response, next: NextFunction) => {
+      res.setHeader('X-Robots-Tag', ROBOTS_NOINDEX_HEADER_VALUE);
+      next();
+    });
+  }
+
+  const expressApp = app.getHttpAdapter().getInstance();
+  expressApp.get('/robots.txt', (_req: Request, res: Response) => {
+    res.type('text/plain');
+    res.setHeader('Cache-Control', 'no-store');
+    res.send(getRobotsTxt(robotsTxt));
+  });
+}

--- a/src/robots-indexing.ts
+++ b/src/robots-indexing.ts
@@ -20,8 +20,9 @@ export function configureRobotsIndexing(
   app: NestExpressApplication,
   config: ConfigService,
 ): void {
-  const robotsTxt = config.get<string>(ROBOTS_TXT_ENV);
-  const hasCustomRobotsTxt = robotsTxt !== undefined && robotsTxt !== '';
+  const robotsTxt = config.get<string | null>(ROBOTS_TXT_ENV);
+  const hasCustomRobotsTxt =
+    robotsTxt !== undefined && robotsTxt !== null && robotsTxt !== '';
 
   if (!hasCustomRobotsTxt) {
     app.use((_req: Request, res: Response, next: NextFunction) => {

--- a/src/robots-indexing.ts
+++ b/src/robots-indexing.ts
@@ -12,7 +12,7 @@ export function getRobotsTxt(value: string | null | undefined): string {
     return DEFAULT_ROBOTS_TXT;
   }
 
-  const robotsTxt = value.replace(/\\n/g, '\n');
+  const robotsTxt = value.replaceAll('\\n', '\n');
   return robotsTxt.endsWith('\n') ? robotsTxt : `${robotsTxt}\n`;
 }
 

--- a/src/robots-indexing.ts
+++ b/src/robots-indexing.ts
@@ -12,7 +12,7 @@ export function getRobotsTxt(value: string | null | undefined): string {
     return DEFAULT_ROBOTS_TXT;
   }
 
-  const robotsTxt = value.replaceAll('\\n', '\n');
+  const robotsTxt = value.replaceAll(String.raw`\n`, '\n');
   return robotsTxt.endsWith('\n') ? robotsTxt : `${robotsTxt}\n`;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable custom robots.txt via environment variable; defaults to private (blocks crawlers) if unset.
  * Serve a /robots.txt endpoint that returns normalized content and applies appropriate no-store caching.
  * Apply global X‑Robots‑Tag noindex header when no custom robots.txt is configured.

* **Documentation**
  * Documented the environment variable, default /robots.txt content, and newline formatting rules.

* **Tests**
  * Added tests for robots.txt normalization, newline handling, and default behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->